### PR TITLE
small (typographic) fixes

### DIFF
--- a/draft-frost-rats-eat-collection.md
+++ b/draft-frost-rats-eat-collection.md
@@ -49,7 +49,8 @@ informative:
     author:
       org: "Arm Ltd"
     title: "Confidential Compute Architecture"
-    url: https://www.arm.com/architecture/security-features/arm-confidential-compute-architecture
+    target: https://www.arm.com/architecture/security-features/arm-confidential-compute-architecture
+    date: 2022
 
 entity:
   SELF: "RFCthis"

--- a/draft-frost-rats-eat-collection.md
+++ b/draft-frost-rats-eat-collection.md
@@ -31,14 +31,18 @@ contributor:
   email: thomas.fossati@arm.com
 
 normative:
-  I-D.ietf-rats-eat:
+  I-D.ietf-rats-eat: eat
   IANA.cbor-tags:
-  RFC8610:
+  RFC8610: cddl
+  RFC9165: cddlplus
 
 informative:
   I-D.ietf-rats-uccs:
+  I-D.ietf-rats-architecture: rats-architecture
   RFC8392:
-  RFC8152:
+  STD96:
+    -: cose
+    =: RFC9052
   RFC7519:
   RFC7515:
   Arm-CCA:
@@ -58,11 +62,19 @@ The default top-level definitions for an EAT {{I-D.ietf-rats-eat}} assume a hier
 
 # Introduction
 
-An Attestation Token conforming to EAT {{I-D.ietf-rats-eat}} has a default top level definition for a token to be constructed principally as a claim set within a CBOR Web Token (CWT) {{RFC8392}} with the associated COSE envelope {{RFC8152}} providing at least integrity and authentication. An equivalent JSON encoding for a JWT {{RFC7519}} in a JWS envelope {{RFC7515}} is supported as an alternative at the top-level definition. The top level token can be augmented with related claims in a Detached EAT Bundle.
+An Attestation Token conforming to EAT {{I-D.ietf-rats-eat}} has a default top level definition for a token to be constructed principally as a claim set within a CBOR Web Token (CWT) {{RFC8392}} with the associated COSE envelope {{-cose}} providing at least integrity and authentication. An equivalent JSON encoding for a JWT {{RFC7519}} in a JWS envelope {{RFC7515}} is supported as an alternative at the top-level definition. The top level token can be augmented with related claims in a Detached EAT Bundle.
 
 For the use case of transmitting a claim set through a secure channel, the top-level definition can be extended to use an Unprotected CWT Claim Set (UCCS) {{I-D.ietf-rats-uccs}}.
 
 This document outlines an additional top-level extension for which neither of the above top level definitions match exactly: the attestation token consists of a collection of objects, each with their own integrity and some internally defined relationship through which the integrity of the whole collection can be determined. i.e. there is no top-level signer for the set. The objects may all share the same logical hierarchy in a device or have a hierarchy which is internally defined within the object set.
+
+# Terminology and Requirements Language
+
+Readers are also expected to be familiar with the terminology from {{-eat}} and {{-rats-architecture}}.
+
+In this document, the structure of data is specified in CDDL {{-cddl}} {{-cddlplus}}.
+
+{::boilerplate bcp14-tagged}
 
 # Design Considerations / Use Cases
 
@@ -72,7 +84,6 @@ A specific manifestation of such a device is one incorporating the Arm Confident
 
 To support the CCA use case, it is also relevant to consider current attestation technologies which are based on certificate chains (e.g. SPDM, DICE, several key attestation systems). Here also are multiple objects with their own integrity and an internally defined relationship. If attempting to move such a technology to the EAT world, the same challenges apply.
 
-
 # Token Collection
 
 The proposed extension for the top-level definition is to add a 'Token Collection' type. The contents of the type are a map of CWTs (JWTs). The Detached EAT Bundle top-level entry for EAT is included for completeness, and the UCCS extension can also be embraced, though the use cases for these have not been explored. The identification of collection members and the intra collection integrity mechanism is considered usage specific. A verifier will be expected to extract each of the members of the collection and check their validity both individually and as a set. In addition to entries which have their own integrity, it is also
@@ -81,28 +92,30 @@ within another entry that uses one of the signed forms.
 
 A map was chosen rather than an unbounded array to give the opportunity to add identifying map tags to each entry. The interpretation of the tags will be usage specific, but may correspond to registered identities of specific token types. To assist a verifier correlate the expected contents a profile entry can be added as the ‘profile-label’ identity in the map.
 
-See {{cddl}} for a CDDL {{RFC8610}} description of the proposed extension.
+See {{cddl}} for a CDDL description of the proposed extension.
 
 While most of the use cases for collections are for scenarios where there will be at least two entries in a collection, the CDDL allows for >= 1 entries in a collection to allow for the scenario where only one entry is currently available even though the normal set is larger.
 
 ## Binder Definition
-This specification includes a proposal for a Collection Binder claim (see CDDL). This claim would be
+This specification includes a proposal for a Collection Binder claim (see {{cddl}}). This claim would be
 included within any collection entry as a definiton of the integrity mechanism that binds that collection
 entry to another collection entry. A verifier can use the information within this claim to drive inter
 collection entry integrity checking. This claim would not be mandatory within a collection entry as a
 verifier may implement the integrity checking based upon information in the profile alone.
 The attributes within the binder claim are:
-+ binder-function: the identity of the binding cryptographic function, usually a hash function, applied
+
++ `binder-function`: the identity of the binding cryptographic function, usually a hash function, applied
 to the values identified by the binder-source-label array.
-+ binder-source-label: an array defining the set of claims providing the binding information within the
++ `binder-source-label`: an array defining the set of claims providing the binding information within the
 collection entry. It is assumed that the values corresponding to this (ordered) list will be concatenated
 and have the binder-function applied to produce a binder value. If the array is empty, the entire source
 collection entry is used as input to the binder-function. This latter condition would normally be applied
 to a collection entry consisting of a Claim Set.
-+ destination-collection-entry: this defines the collection entry that will hold (receive) the binding
++ `destination-collection-entry`: this defines the collection entry that will hold (receive) the binding
 for this (source) collection entry.
-+ destination-claim: this defines the claim label within destination-collection-entry which will store
++ `destination-claim`: this defines the claim label within destination-collection-entry which will store
 the binder value.
+
 A verifier can check the binding between two collection entries by computing the binder value for one
 entry and comparing the result stored within the value of the destination claim (in the destination
 collection entry).
@@ -170,9 +183,9 @@ detatched-eat-bundle-collection-entries = (
 
 collection-entry-label = JC<text, int>
 
-; The Collection Binder is a formal declaration of the inter entry binding
-; mechanism. It would be included within the body of one or more of the
-; collection entries.
+; The Collection Binder is a formal declaration of the inter entry
+; binding mechanism. It would be included within the body of one or
+; more of the collection entries.
 Tagged-Collection-Binder =  #6.TBD99(Collection-Binder)
 Collection-Binder = [
     binder-function,
@@ -183,10 +196,10 @@ Collection-Binder = [
 ; binder function is normally the name/id of a hash algorithm
 binder-function = JC<text,int>
 
-; by definition, the binder-function is applied to a concatenation of the
-; ordered list of source claims
-; If the array is empty, the function is applied to the whole contents of
-; the token
+; by definition, the binder-function is applied to a concatenation
+; of the ordered list of source claims
+; If the array is empty, the function is applied to the whole
+; contents of the token
 binder-source-label = Claim-Label
 
 destination-collection-entry = collection-entry-label


### PR DESCRIPTION
A bunch of small typographic fixes, specifically:

* enforce 72 char limit in CDDL comments
* add the usual "Terminology and Requirement Language" section
* bulleted list need a NL to render properly
* fix COSE ref (9052 obsoletes 8152)
* highlight terms in the binder definition
* fix CCA reference entry