### PR TITLE
separate the binder CDDL from the EAT collection proper...

### DIFF
--- a/cddl/collection-binder.cddl
+++ b/cddl/collection-binder.cddl
@@ -1,0 +1,25 @@
+; The Collection Binder is a formal declaration of the inter entry
+; binding mechanism. It would be included within the body of one or
+; more of the collection entries. 
+Collection-Binder = [
+    binder-function,
+    [*binder-source-label],
+    destination-collection-entry,
+    destination-claim
+]
+
+; binder-function is the name/id of a hash algorithm
+binder-function = JC<text,int>
+
+; By definition, the binder-function is applied to a concatenation
+; of the ordered list of source claims.
+; If the array is empty, the function is applied to the whole
+; contents of the token.
+binder-source-label = Claim-Label
+
+destination-collection-entry = collection-entry-label
+destination-claim = Claim-Label
+
+Claim-Label = JC<"text", int>
+collection-entry-label = JC<text, int>
+JC<J,C> = J .feature "json" / C .feature "cbor"

--- a/cddl/eat-collection.cddl
+++ b/cddl/eat-collection.cddl
@@ -42,30 +42,6 @@ detatched-eat-bundle-collection-entries = (
 
 collection-entry-label = JC<text, int>
 
-; The Collection Binder is a formal declaration of the inter entry binding
-; mechanism. It would be included within the body of one or more of the
-; collection entries. 
-Tagged-Collection-Binder =  #6.99(Collection-Binder)
-Collection-Binder = [
-    binder-function,
-    [*binder-source-label],
-    destination-collection-entry,
-    destination-claim
-]
-; binder function is normally the name/id of a hash algorithm
-binder-function = JC<text,int>
-
-; by definition, the binder-function is applied to a concatenation of the
-; ordered list of source claims
-; If the array is empty, the function is applied to the whole contents of
-; the token
-binder-source-label = Claim-Label
-
-destination-collection-entry = collection-entry-label
-
-destination-claim = Claim-Label
-
-
 ; required placeholders for standalone checking
 CWT-Messages = bstr .cbor CWT-placeholder
 JWT-Messages = "jwt-placeholder"

--- a/draft-frost-rats-eat-collection.md
+++ b/draft-frost-rats-eat-collection.md
@@ -98,11 +98,17 @@ See {{cddl}} for a CDDL description of the proposed extension.
 While most of the use cases for collections are for scenarios where there will be at least two entries in a collection, the CDDL allows for >= 1 entries in a collection to allow for the scenario where only one entry is currently available even though the normal set is larger.
 
 ## Binder Definition
-This specification includes a proposal for a Collection Binder claim (see {{cddl}}). This claim would be
+This specification includes a proposal for a Collection Binder claim (see {{fig-binder}}). This claim would be
 included within any collection entry as a definiton of the integrity mechanism that binds that collection
 entry to another collection entry. A verifier can use the information within this claim to drive inter
 collection entry integrity checking. This claim would not be mandatory within a collection entry as a
 verifier may implement the integrity checking based upon information in the profile alone.
+
+~~~ cddl
+{::include cddl/collection-binder.cddl}
+~~~
+{: #fig-binder title="EAT collection binder" }
+
 The attributes within the binder claim are:
 
 + `binder-function`: the identity of the binding cryptographic function, usually a hash function, applied


### PR DESCRIPTION
...and include it in the relevant section